### PR TITLE
Fix ConvexHull constructor, add tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,11 @@
+using Test
+using DirectQhull
+
+@testset "ConvexHull Tests" begin
+    points = [0 0 1 1 0.5 0.5 0.5; 0 1 0 1 0.5 0.3 0.7]  # Points that form a square with additional points in the interior
+    hull = ConvexHull(points)
+
+    @test all([v in 1:size(points, 2) for v in hull.vertices])
+    expected_vertices = [1, 2, 3, 4]  # Indices of the corners of the square
+    @test sort(hull.vertices) == sort(expected_vertices)
+end


### PR DESCRIPTION
It seems that recent changes must have added a field to `ConvexHull`, but the `new`
statement was not correspondingly updated. This adds tests for construction and
whether the expected vertices are returned for a simple problem.